### PR TITLE
BS-14315, add migration step to drop table arch_transition_instance

### DIFF
--- a/bonita-migration-distrib/build.gradle
+++ b/bonita-migration-distrib/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     testCompile "org.spockframework:spock-core:1.0-groovy-2.3"
     testRuntime "cglib:cglib-nodep:2.2"
     testRuntime 'org.objenesis:objenesis:1.2'
+    testCompile( 'org.dbunit:dbunit:2.5.1' )
 }

--- a/bonita-migration-distrib/src/it/groovy/org/bonitasoft/migration/DBUnitHelper.groovy
+++ b/bonita-migration-distrib/src/it/groovy/org/bonitasoft/migration/DBUnitHelper.groovy
@@ -1,0 +1,165 @@
+/*
+ *
+ * Copyright (C) 2014 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bonitasoft.migration
+
+import groovy.sql.Sql
+import groovy.xml.StreamingMarkupBuilder
+import org.dbunit.JdbcDatabaseTester
+import org.dbunit.database.IDatabaseConnection
+import org.dbunit.dataset.ReplacementDataSet
+import org.dbunit.dataset.xml.FlatXmlDataSet
+import org.dbunit.ext.oracle.OracleConnection
+
+import java.sql.DriverManager
+
+/**
+ * @author Baptiste Mesta
+ */
+class DBUnitHelper {
+
+    static Map trueValueMap = [
+            "oracle"   : 1,
+            "postgres" : true,
+            "mysql"    : true,
+            "sqlserver": true
+    ]
+    static Map falseValueMap = [
+            "oracle"   : 0,
+            "postgres" : false,
+            "mysql"    : false,
+            "sqlserver": false
+    ]
+    public static final String POSTGRES = "postgres"
+    public static final String ORACLE = "oracle"
+    public static final String MYSQL = "mysql"
+
+    static trueValue() {
+        trueValueMap.get(dbVendor())
+    }
+
+    static falseValue() {
+        falseValueMap.get(dbVendor())
+
+    }
+
+    static String dbVendor() {
+        System.getProperty("dbvendor")
+    }
+
+
+    def static dataSet(data) {
+        new ReplacementDataSet(new FlatXmlDataSet(new StringReader(new StreamingMarkupBuilder().bind {
+            dataset data
+        }.toString())), ["[NULL]": null], null)
+    }
+
+    def static getCreateTables(String version, String feature) {
+        DBUnitHelper.class.getClassLoader().getResource("sql/v${version}/${dbVendor()}-${feature}.sql");
+    }
+
+    def static String[] createTables(sql, String version, String feature) {
+        println "Create tables of $feature"
+        getCreateTables(version, feature).text.split("@@").each({ stmt ->
+            sql.execute(stmt)
+        })
+    }
+
+    def static boolean hasTable(Sql sql, String tableName) {
+        def firstRow
+        switch (dbVendor()) {
+            case POSTGRES:
+                def query = """
+                    SELECT *
+                     FROM information_schema.tables
+                     WHERE table_schema='public'
+                       AND table_type='BASE TABLE'
+                       AND table_name = ?
+                    """
+                firstRow = sql.firstRow(query, tableName)
+                break
+
+            case ORACLE:
+                def query = """
+                    SELECT *
+                    FROM user_tables
+                    WHERE table_name = ?
+                    OR table_name = ?
+                    """ as String
+                firstRow = sql.firstRow(query, [tableName, tableName.toUpperCase()])
+                break
+
+            case MYSQL:
+                def query = """
+                    SELECT *
+                    FROM information_schema.tables
+                    WHERE table_name = ?
+                    AND table_schema = DATABASE()
+                    """
+                firstRow = sql.firstRow(query, tableName)
+                break
+
+            case "sqlserver":
+                def query = """
+                    SELECT * FROM information_schema.tables
+                    WHERE TABLE_NAME = ?
+                    """
+                firstRow = sql.firstRow(query, tableName)
+                break
+        }
+        return firstRow != null
+    }
+
+    def static JdbcDatabaseTester createTester() {
+        new JdbcDatabaseTester(driverClass, url, user, password) {
+            public IDatabaseConnection getConnection() {
+                if (dbVendor() == ORACLE) {
+                    def conn = DriverManager.getConnection(getUrl(), getUser(), getPassword());
+                    return new OracleConnection(conn, getUser());
+                } else {
+                    return super.getConnection();
+                }
+            }
+        }
+    }
+
+    def static Sql createSqlConnection() {
+        Sql.newInstance(url, user, password, driverClass)
+    }
+
+    def static String getPassword() {
+        System.getProperty("dbpassword")
+    }
+
+    def static String getUser() {
+        System.getProperty("dbuser")
+    }
+
+    def static String getUrl() {
+        System.getProperty("dburl")
+    }
+
+    def static String getDriverClass() {
+        System.getProperty("dbdriverClass")
+    }
+
+    def static dropTables(Sql sql, String[] tables) {
+        tables.each {
+            sql.execute("DROP TABLE $it".toString())
+        }
+    }
+
+}

--- a/bonita-migration-distrib/src/it/groovy/org/bonitasoft/migration/version/DBUnitMigrationContext.groovy
+++ b/bonita-migration-distrib/src/it/groovy/org/bonitasoft/migration/version/DBUnitMigrationContext.groovy
@@ -1,0 +1,25 @@
+package org.bonitasoft.migration.version
+
+import groovy.sql.Sql
+import org.bonitasoft.migration.core.MigrationContext
+import org.bonitasoft.migration.core.MigrationStep
+import org.bonitasoft.migration.core.database.DatabaseHelper
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+class DBUnitMigrationContext extends  MigrationContext {
+
+
+    DBUnitMigrationContext(Sql sql) {
+        this.sql = sql
+
+        def dBVendor = MigrationStep.DBVendor.valueOf(System.getProperty("dbvendor", "POSTGRES").toUpperCase())
+        this.databaseHelper = new DatabaseHelper(dbVendor: dBVendor, sql: sql)
+    }
+
+    @Override
+    def openSqlConnection() {
+        // nothing to do
+    }
+}

--- a/bonita-migration-distrib/src/it/groovy/org/bonitasoft/migration/version/to7_1_1/EnsureDroppedArchTransitionInstIT.groovy
+++ b/bonita-migration-distrib/src/it/groovy/org/bonitasoft/migration/version/to7_1_1/EnsureDroppedArchTransitionInstIT.groovy
@@ -1,0 +1,37 @@
+package org.bonitasoft.migration.version.to7_1_1
+import groovy.sql.Sql
+import org.bonitasoft.migration.DBUnitHelper
+import org.bonitasoft.migration.version.DBUnitMigrationContext
+import spock.lang.Shared
+import spock.lang.Specification
+/**
+ * @author Elias Ricken de Medeiros
+ */
+class EnsureDroppedArchTransitionInstIT extends Specification {
+
+    @Shared
+    Sql sql = DBUnitHelper.createSqlConnection()
+
+    def "should drop arch_transition_instance table when exists"() {
+        DBUnitHelper.createTables(sql, "7_0_0", "archTransition")
+
+        when:
+        new EnsureDroppedArchTransitionInst().execute(new DBUnitMigrationContext(sql))
+
+        then:
+        DBUnitHelper.hasTable(sql, "arch_transition_instance") == false
+
+        //clean up
+        DBUnitHelper.dropTables(sql, "tenant")
+
+    }
+
+    def "execution step should not throws exception when the table arch_transition_instance does not exist"() {
+        when:
+        new EnsureDroppedArchTransitionInst().execute(new DBUnitMigrationContext(sql))
+
+        then:
+        DBUnitHelper.hasTable(sql, "arch_transition_instance") == false
+
+    }
+}

--- a/bonita-migration-distrib/src/it/resources/sql/v7_0_0/mysql-archTransition.sql
+++ b/bonita-migration-distrib/src/it/resources/sql/v7_0_0/mysql-archTransition.sql
@@ -1,0 +1,30 @@
+
+CREATE TABLE tenant (
+  id BIGINT NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE = INNODB;
+
+CREATE TABLE arch_transition_instance (
+  tenantid BIGINT NOT NULL,
+  id BIGINT NOT NULL,
+  rootContainerId BIGINT NOT NULL,
+  parentContainerId BIGINT NOT NULL,
+  source BIGINT,
+  target BIGINT,
+  state VARCHAR(50),
+  terminal BOOLEAN NOT NULL,
+  stable BOOLEAN ,
+  stateCategory VARCHAR(50) NOT NULL,
+  logicalGroup1 BIGINT NOT NULL,
+  logicalGroup2 BIGINT NOT NULL,
+  logicalGroup3 BIGINT,
+  logicalGroup4 BIGINT NOT NULL,
+  description VARCHAR(255),
+  sourceObjectId BIGINT,
+  archiveDate BIGINT NOT NULL,
+  PRIMARY KEY (tenantid, id)
+) ENGINE = INNODB;
+
+CREATE INDEX idx1_arch_transition_instance ON arch_transition_instance (tenantid, rootcontainerid);
+
+ALTER TABLE arch_transition_instance ADD CONSTRAINT fk_arch_transition_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);

--- a/bonita-migration-distrib/src/it/resources/sql/v7_0_0/oracle-archTransition.sql
+++ b/bonita-migration-distrib/src/it/resources/sql/v7_0_0/oracle-archTransition.sql
@@ -1,0 +1,29 @@
+CREATE TABLE tenant (
+  id NUMBER(19, 0) NOT NULL,
+  PRIMARY KEY (id)
+)@@
+
+CREATE TABLE arch_transition_instance (
+  tenantid NUMBER(19, 0) NOT NULL,
+  id NUMBER(19, 0) NOT NULL,
+  rootContainerId NUMBER(19, 0) NOT NULL,
+  parentContainerId NUMBER(19, 0) NOT NULL,
+  source NUMBER(19, 0),
+  target NUMBER(19, 0),
+  state VARCHAR2(50 CHAR),
+  terminal NUMBER(1) NOT NULL,
+  stable NUMBER(1) ,
+  stateCategory VARCHAR2(50 CHAR) NOT NULL,
+  logicalGroup1 NUMBER(19, 0) NOT NULL,
+  logicalGroup2 NUMBER(19, 0) NOT NULL,
+  logicalGroup3 NUMBER(19, 0),
+  logicalGroup4 NUMBER(19, 0) NOT NULL,
+  description VARCHAR2(255 CHAR),
+  sourceObjectId NUMBER(19, 0),
+  archiveDate NUMBER(19, 0) NOT NULL,
+  PRIMARY KEY (tenantid, id)
+)@@
+
+CREATE INDEX idx1_arch_transition_instance ON arch_transition_instance (tenantid, rootcontainerid)@@
+
+ALTER TABLE arch_transition_instance ADD CONSTRAINT fk_ATrans_tenId FOREIGN KEY (tenantid) REFERENCES tenant(id)@@

--- a/bonita-migration-distrib/src/it/resources/sql/v7_0_0/postgres-archTransition.sql
+++ b/bonita-migration-distrib/src/it/resources/sql/v7_0_0/postgres-archTransition.sql
@@ -1,0 +1,29 @@
+CREATE TABLE tenant (
+  id INT8 NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE arch_transition_instance (
+  tenantid INT8 NOT NULL,
+  id INT8 NOT NULL,
+  rootContainerId INT8 NOT NULL,
+  parentContainerId INT8 NOT NULL,
+  source INT8,
+  target INT8,
+  state VARCHAR(50),
+  terminal BOOLEAN NOT NULL,
+  stable BOOLEAN ,
+  stateCategory VARCHAR(50) NOT NULL,
+  logicalGroup1 INT8 NOT NULL,
+  logicalGroup2 INT8 NOT NULL,
+  logicalGroup3 INT8,
+  logicalGroup4 INT8 NOT NULL,
+  description VARCHAR(255),
+  sourceObjectId INT8,
+  archiveDate INT8 NOT NULL,
+  PRIMARY KEY (tenantid, id)
+);
+
+CREATE INDEX idx1_arch_transition_instance ON arch_transition_instance (tenantid, rootcontainerid);
+
+ALTER TABLE arch_transition_instance ADD CONSTRAINT fk_arch_transition_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);

--- a/bonita-migration-distrib/src/it/resources/sql/v7_0_0/sqlserver-archTransition.sql
+++ b/bonita-migration-distrib/src/it/resources/sql/v7_0_0/sqlserver-archTransition.sql
@@ -1,0 +1,41 @@
+CREATE TABLE tenant (
+  id NUMERIC(19, 0) NOT NULL,
+  created NUMERIC(19, 0) NOT NULL,
+  createdBy NVARCHAR(50) NOT NULL,
+  description NVARCHAR(255),
+  defaultTenant BIT NOT NULL,
+  iconname NVARCHAR(50),
+  iconpath NVARCHAR(255),
+  name NVARCHAR(50) NOT NULL,
+  status NVARCHAR(15) NOT NULL,
+  PRIMARY KEY (id)
+)
+@@
+
+CREATE TABLE arch_transition_instance (
+  tenantid NUMERIC(19, 0) NOT NULL,
+  id NUMERIC(19, 0) NOT NULL,
+  rootContainerId NUMERIC(19, 0) NOT NULL,
+  parentContainerId NUMERIC(19, 0) NOT NULL,
+  source NUMERIC(19, 0),
+  target NUMERIC(19, 0),
+  state NVARCHAR(50),
+  terminal BIT NOT NULL,
+  stable BIT ,
+  stateCategory NVARCHAR(50) NOT NULL,
+  logicalGroup1 NUMERIC(19, 0) NOT NULL,
+  logicalGroup2 NUMERIC(19, 0) NOT NULL,
+  logicalGroup3 NUMERIC(19, 0),
+  logicalGroup4 NUMERIC(19, 0) NOT NULL,
+  description NVARCHAR(255),
+  sourceObjectId NUMERIC(19, 0),
+  archiveDate NUMERIC(19, 0) NOT NULL,
+  PRIMARY KEY (tenantid, id)
+)
+@@
+
+CREATE INDEX idx1_arch_transition_instance ON arch_transition_instance (tenantid, rootcontainerid)
+@@
+
+ALTER TABLE arch_transition_instance ADD CONSTRAINT fk_arch_transition_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id)
+@@

--- a/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/version/to7_1_1/EnsureDroppedArchTransitionInst.groovy
+++ b/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/version/to7_1_1/EnsureDroppedArchTransitionInst.groovy
@@ -1,0 +1,21 @@
+package org.bonitasoft.migration.version.to7_1_1
+
+import org.bonitasoft.migration.core.MigrationContext
+import org.bonitasoft.migration.core.MigrationStep
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+class EnsureDroppedArchTransitionInst extends MigrationStep {
+
+
+    @Override
+    def execute(MigrationContext context) {
+        context.databaseHelper.dropTableIfExists("arch_transition_instance")
+    }
+
+    @Override
+    String getDescription() {
+        return "drop table arch_transition_instance if exists"
+    }
+}

--- a/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/version/to7_1_1/MigrateTo7_1_1.groovy
+++ b/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/version/to7_1_1/MigrateTo7_1_1.groovy
@@ -25,7 +25,8 @@ class MigrateTo7_1_1 extends VersionMigration {
     def List<MigrationStep> getMigrationSteps() {
         //keep one line per step to avoid false-positive merge conflict
         return [
-                new MigrateQuartzRenameColumn()
+                new MigrateQuartzRenameColumn(),
+                new EnsureDroppedArchTransitionInst()
         ]
     }
 }

--- a/bonita-migration-distrib/src/test/groovy/org/bonitasoft/migration/version/to7_1_1/EnsureDroppedArchTransitionInstTest.groovy
+++ b/bonita-migration-distrib/src/test/groovy/org/bonitasoft/migration/version/to7_1_1/EnsureDroppedArchTransitionInstTest.groovy
@@ -1,0 +1,37 @@
+package org.bonitasoft.migration.version.to7_1_1
+import org.bonitasoft.migration.core.MigrationContext
+import org.bonitasoft.migration.core.database.DatabaseHelper
+import spock.lang.Specification
+/**
+ * @author Elias Ricken de Medeiros
+ */
+class EnsureDroppedArchTransitionInstTest extends Specification {
+
+    def EnsureDroppedArchTransitionInst migrationStep = new EnsureDroppedArchTransitionInst()
+    def databaseHelper = Mock(DatabaseHelper)
+    def context = Mock(MigrationContext)
+
+    def setup () {
+        context.databaseHelper >> databaseHelper
+    }
+
+
+    def "execute should call dropTableIfExits"() {
+        when:
+        migrationStep.execute(context)
+
+        then:
+        1 * databaseHelper.dropTableIfExists("arch_transition_instance")
+
+    }
+
+    def "GetDescription should return the description"() {
+
+        when:
+        def description = migrationStep.getDescription()
+
+        then:
+        description == "drop table arch_transition_instance if exists"
+
+    }
+}

--- a/bonita-migration-distrib/src/test/groovy/org/bonitasoft/migration/version/to7_1_1/MigrateTo7_1_1Test.groovy
+++ b/bonita-migration-distrib/src/test/groovy/org/bonitasoft/migration/version/to7_1_1/MigrateTo7_1_1Test.groovy
@@ -1,0 +1,24 @@
+package org.bonitasoft.migration.version.to7_1_1
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+@Unroll
+class MigrateTo7_1_1Test extends Specification {
+
+    def "should contains #step" (){
+        def migration = new MigrateTo7_1_1();
+
+        expect:
+        migration.getMigrationSteps().get(index).getClass() == step
+
+        where:
+        index || step
+        0 || MigrateQuartzRenameColumn
+        1 || EnsureDroppedArchTransitionInst
+    }
+
+}


### PR DESCRIPTION
This table will exists for all Bonita BPM Platform created under 7.0.x and 7.1.0;
Users coming from  versions  6.x will have this table dropped when migration to version 7.0.0