### PR TITLE
 fix(migration): out of memory in 6.3.9 to 6.4.0 step

### DIFF
--- a/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocument.groovy
+++ b/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocument.groovy
@@ -1,0 +1,58 @@
+/*
+ *
+ * Copyright (C) 2016 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bonitasoft.migration.versions.v6_3_9_to_6_4_0
+/**
+ * @author Laurent Leseigneur
+ */
+class MigrateDocument {
+    def tenantId
+    def nextId
+    def falseValue
+    def trueValue
+    def sql
+
+    protected MigrateDocument(def sql, def tenantId, def nextId, def falseValue, def trueValue) {
+        this.sql = sql
+        this.trueValue = trueValue
+        this.falseValue = falseValue
+        this.nextId = nextId
+        this.tenantId = tenantId
+    }
+
+    def createTempSequence() {}
+
+    def createTempDocTable() {}
+
+    def updateDocumentMapping() {}
+
+    def createTempArchDocTable() {}
+
+    def updateArchDocumentMapping() {}
+
+    def updateSequenceValue() {}
+
+    def createTempArchVersionTable() {}
+
+    def createTempVersionTable() {}
+
+    def updateDocumentMappingVersion() {}
+
+    def updateArchDocumentMappingVersion() {}
+
+    def dropTempSequence() {}
+
+}

--- a/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocumentMysql.groovy
+++ b/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocumentMysql.groovy
@@ -1,0 +1,159 @@
+/*
+ *
+ * Copyright (C) 2016 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bonitasoft.migration.versions.v6_3_9_to_6_4_0
+/**
+ * @author Laurent Leseigneur
+ */
+class MigrateDocumentMysql extends MigrateDocument {
+
+    public MigrateDocumentMysql(def sql, def tenantId, def nextId, def falseValue, def trueValue) {
+        super(sql, tenantId, nextId, falseValue, trueValue)
+    }
+
+    def createTempSequence() {
+        return
+    }
+
+
+    def createTempDocTable() {
+
+        sql.execute("""
+                        CREATE TABLE temp_doc (
+                            tenant_id BIGINT NOT NULL,
+                            doc_mapping_id BIGINT NOT NULL,
+                            doc_id BIGINT NOT NULL AUTO_INCREMENT,
+                            PRIMARY KEY (doc_id)
+                            ) ENGINE = INNODB """)
+
+        sql.execute("ALTER TABLE temp_doc AUTO_INCREMENT = " + nextId)
+
+        sql.execute("""
+                        INSERT INTO temp_doc (tenant_id, doc_mapping_id)
+                        SELECT  d.tenantid, d.id
+                        FROM    document_mapping d
+                        WHERE   tenantid = ? AND documentHasContent = ? """, tenantId, falseValue)
+
+
+        sql.execute("CREATE INDEX temp_doc_idx ON temp_doc(tenant_id,doc_mapping_id)")
+    }
+
+    def updateDocumentMapping() {
+        sql.execute("""
+                    UPDATE document_mapping
+                        INNER JOIN temp_doc t ON tenantid = t.tenant_id AND id = t.doc_mapping_id
+                    SET documentid = t.doc_id""")
+
+    }
+
+    def createTempArchDocTable() {
+
+        sql.execute("""
+                        CREATE TABLE temp_arch_doc (
+                            tenant_id BIGINT NOT NULL,
+                            arch_doc_mapping_id BIGINT NOT NULL,
+                            doc_id BIGINT NOT NULL AUTO_INCREMENT,
+                            PRIMARY KEY (doc_id)
+                            ) ENGINE = INNODB """)
+
+
+        def nextValue = sql.firstRow("SELECT MAX(doc_id) +1  AS nextValue from temp_doc").nextValue
+        sql.execute("ALTER TABLE temp_arch_doc AUTO_INCREMENT = ? ", nextValue)
+
+        sql.execute("""
+                        INSERT INTO temp_arch_doc (tenant_id, arch_doc_mapping_id)
+                        SELECT  d.tenantid, d.id
+                        FROM    arch_document_mapping d
+                        WHERE   d.tenantid = ? AND d.documentHasContent = ? """, tenantId, falseValue)
+
+    }
+
+    def updateArchDocumentMapping() {
+
+        sql.execute("""
+                    UPDATE arch_document_mapping
+                        INNER JOIN temp_arch_doc t ON tenantid = t.tenant_id AND id = t.arch_doc_mapping_id
+                    SET documentid = t.doc_id""")
+
+    }
+
+    def updateSequenceValue() {
+
+        def nextValue = sql.firstRow("SELECT MAX(doc_id) +1  AS nextValue from temp_arch_doc").nextValue
+        sql.execute("""
+                    UPDATE sequence SET nextid = ?
+                    WHERE tenantid = ?
+                    AND id = 10090 """, nextValue, tenantId)
+
+
+    }
+
+    def createTempArchVersionTable() {
+
+        sql.execute("""
+                    CREATE TABLE temp_arch_version AS
+                    SELECT
+                        a.tenantid,
+                        a.id,
+                        a.sourceobjectid,
+                        (   SELECT count(*) +1
+                            FROM arch_document_mapping b
+                            WHERE a.tenantid = a.tenantid
+                                AND a.sourceobjectid = b.sourceobjectid
+                                AND a.documentCreationDate >= b.documentCreationDate
+                                AND a.id > b.id
+                        ) as new_version
+                    FROM arch_document_mapping a
+                    WHERE a.tenantid = ? """, tenantId)
+
+    }
+
+    def createTempVersionTable() {
+
+        sql.execute("""
+                    CREATE TABLE temp_version AS
+                    SELECT
+                        a.tenantid,
+                        a.sourceobjectid,
+                        (max(a.new_version) +1 ) as new_version
+                    FROM temp_arch_version a
+                    WHERE a.tenantid = """ + tenantId + " GROUP BY a.tenantid, a.sourceobjectid ")
+
+    }
+
+    def updateDocumentMappingVersion() {
+
+        sql.execute("""
+                    UPDATE document_mapping INNER JOIN temp_version
+                        ON document_mapping.tenantid = temp_version.tenantid and document_mapping.id = temp_version.sourceobjectid
+                    SET version = temp_version.new_version """)
+
+    }
+
+    def updateArchDocumentMappingVersion() {
+
+        sql.execute("""
+                    UPDATE arch_document_mapping
+                        INNER JOIN temp_arch_version ON arch_document_mapping.tenantid = temp_arch_version.tenantid
+                            AND arch_document_mapping.id = temp_arch_version.id
+                    SET version = temp_arch_version.new_version """)
+
+    }
+
+    def dropTempSequence() {
+        return
+    }
+}

--- a/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocumentOracle.groovy
+++ b/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocumentOracle.groovy
@@ -1,0 +1,145 @@
+/*
+ *
+ * Copyright (C) 2016 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bonitasoft.migration.versions.v6_3_9_to_6_4_0
+/**
+ * @author Laurent Leseigneur
+ */
+class MigrateDocumentOracle extends MigrateDocument {
+
+    public MigrateDocumentOracle(def sql, def tenantId, def nextId, def falseValue, def trueValue) {
+        super(sql, tenantId, nextId, falseValue, trueValue)
+    }
+
+    def createTempSequence() {
+        sql.execute "CREATE SEQUENCE seq_document START WITH " + nextId + " CACHE 1000 NOCYCLE"
+
+    }
+
+    def createTempDocTable() {
+        sql.execute("""
+                        CREATE TABLE temp_doc AS
+                        SELECT  d.tenantid AS tenant_id, d.id AS doc_mapping_id, seq_document.nextval AS doc_id
+                        FROM    document_mapping d
+                        WHERE   tenantid = """ + tenantId + " AND documentHasContent = " + falseValue)
+
+
+        sql.execute("CREATE INDEX temp_doc_idx ON temp_doc(tenant_id,doc_mapping_id)")
+    }
+
+    def updateDocumentMapping() {
+        sql.execute("""
+                    UPDATE document_mapping d SET d.documentid =(
+                        SELECT  t.doc_id
+                        FROM temp_doc t
+                        WHERE d.tenantid = t.tenant_id
+                        AND d.id = t.doc_mapping_id)
+                    WHERE tenantid = ? AND documentHasContent = ? """, tenantId, falseValue)
+
+    }
+
+    def createTempArchDocTable() {
+        sql.execute("""
+                        CREATE TABLE temp_arch_doc AS
+                        SELECT  d.tenantid AS tenant_id, d.id AS arch_doc_mapping_id, seq_document.nextval AS doc_id
+                        FROM    arch_document_mapping d
+                        WHERE   d.tenantid = """ + tenantId + " AND d.documentHasContent = " + falseValue)
+
+    }
+
+    def updateArchDocumentMapping() {
+        sql.execute("""
+                    UPDATE arch_document_mapping a SET a.documentid = (
+                        SELECT  t.doc_id
+                        FROM temp_arch_doc t
+                        WHERE a.tenantid = t.tenant_id
+                        AND a.id = t.arch_doc_mapping_id )
+                     WHERE tenantid = ? AND documentHasContent = ? """, tenantId, falseValue)
+
+
+    }
+
+    def updateSequenceValue() {
+        sql.execute("""
+                    UPDATE sequence SET nextid = seq_document.currval +1
+                    WHERE tenantid = $tenantId
+                    AND id = 10090 """)
+
+
+    }
+
+    def createTempArchVersionTable() {
+        sql.execute("""
+                    CREATE TABLE temp_arch_version AS
+                    SELECT
+                        a.tenantid,
+                        a.id,
+                        a.sourceobjectid,
+                        rank() OVER(
+                                PARTITION BY a.tenantid, a.sourceobjectid
+                                ORDER BY documentCreationDate,id ASC
+                        ) as new_version
+                    FROM arch_document_mapping a
+                    WHERE a.tenantid =  """ + tenantId)
+
+
+    }
+
+    def createTempVersionTable() {
+        sql.execute("""
+                    CREATE TABLE temp_version AS
+                    SELECT
+                        a.tenantid,
+                        a.sourceobjectid,
+                        (max(a.new_version) +1 ) as new_version
+                    FROM temp_arch_version a
+                    WHERE a.tenantid = """ + tenantId + " GROUP BY a.tenantid, a.sourceobjectid ")
+
+    }
+
+    def updateDocumentMappingVersion() {
+        sql.execute("""
+                    UPDATE document_mapping SET version = (
+                        SELECT temp_version.new_version
+                        FROM temp_version
+                        WHERE document_mapping.tenantid = temp_version.tenantid
+                        AND document_mapping.id = temp_version.sourceobjectid )
+                    WHERE document_mapping.TENANTID= """ + tenantId + """
+                    AND EXISTS
+                        (SELECT 1
+                        FROM temp_version
+                        WHERE document_mapping.tenantid = temp_version.tenantid
+                        AND document_mapping.id = temp_version.sourceobjectid )""")
+
+    }
+
+    def updateArchDocumentMappingVersion() {
+        sql.execute("""
+                    UPDATE arch_document_mapping SET version = (
+                        SELECT temp_arch_version.new_version
+                        FROM temp_arch_version
+                        WHERE arch_document_mapping.tenantid = temp_arch_version.tenantid
+                        AND arch_document_mapping.id = temp_arch_version.id )
+                    WHERE arch_document_mapping.tenantid= """ + tenantId)
+
+    }
+
+    def dropTempSequence() {
+        sql.execute("drop sequence seq_document")
+
+    }
+
+}

--- a/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocumentPostgres.groovy
+++ b/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocumentPostgres.groovy
@@ -1,0 +1,135 @@
+/*
+ *
+ * Copyright (C) 2016 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bonitasoft.migration.versions.v6_3_9_to_6_4_0
+/**
+ * @author Laurent Leseigneur
+ */
+class MigrateDocumentPostgres extends MigrateDocument {
+
+    public MigrateDocumentPostgres(def sql, def tenantId, def nextId, def falseValue, def trueValue) {
+        super(sql, tenantId, nextId, falseValue, trueValue)
+    }
+
+
+    def createTempSequence() {
+        sql.execute "CREATE SEQUENCE seq_document START WITH " + nextId + " CACHE 1000 NO CYCLE"
+
+    }
+
+    def createTempDocTable() {
+        sql.execute("""
+                        CREATE TABLE temp_doc AS
+                        SELECT  d.tenantid AS tenant_id, d.id AS doc_mapping_id, nextval('seq_document') AS doc_id
+                        FROM    document_mapping d
+                        WHERE   tenantid = ? AND documentHasContent = ? """, tenantId, falseValue)
+
+        sql.execute("CREATE INDEX temp_doc_idx ON temp_doc(tenant_id,doc_mapping_id)")
+    }
+
+    def updateDocumentMapping() {
+        sql.execute("""
+                    UPDATE document_mapping SET documentid = t.doc_id
+                    FROM temp_doc t
+                    WHERE tenantid = t.tenant_id
+                    AND id = t.doc_mapping_id """)
+
+    }
+
+    def createTempArchDocTable() {
+        sql.execute("""
+                        CREATE TABLE temp_arch_doc AS
+                        SELECT  d.tenantid AS tenant_id, d.id AS arch_doc_mapping_id, nextval('seq_document') AS doc_id
+                        FROM    arch_document_mapping d
+                        WHERE   d.tenantid = ? AND d.documentHasContent = ? """, tenantId, falseValue)
+
+    }
+
+    def updateArchDocumentMapping() {
+        sql.execute("""
+                    UPDATE arch_document_mapping SET documentid = t.doc_id
+                    FROM temp_arch_doc t
+                    WHERE tenantid = t.tenant_id
+                    AND id = t.arch_doc_mapping_id """)
+
+
+    }
+
+    def updateSequenceValue() {
+        sql.execute("""
+                    UPDATE sequence SET nextid = (currval('seq_document') +1)
+                    WHERE tenantid = ?
+                    AND id = 10090 """, tenantId)
+
+    }
+
+    def createTempArchVersionTable() {
+        sql.execute("""
+                    CREATE TABLE temp_arch_version AS
+                    SELECT
+                        a.tenantid,
+                        a.id,
+                        a.sourceobjectid,
+                        rank() OVER(
+                                PARTITION BY a.tenantid, a.sourceobjectid
+                                ORDER BY documentCreationDate,id ASC
+                        ) as new_version
+                    FROM arch_document_mapping a
+                    WHERE a.tenantid =  """ + tenantId)
+
+    }
+
+    def createTempVersionTable() {
+        sql.execute("""
+                    CREATE TABLE temp_version AS
+                    SELECT
+                        a.tenantid,
+                        a.sourceobjectid,
+                        (max(a.new_version) +1 ) as new_version
+                    FROM temp_arch_version a
+                    WHERE a.tenantid = """ + tenantId + " GROUP BY a.tenantid, a.sourceobjectid ")
+
+    }
+
+
+    def updateDocumentMappingVersion() {
+        sql.execute("""
+                    UPDATE document_mapping SET version = temp_version.new_version
+                    FROM temp_version
+                    WHERE document_mapping.tenantid = temp_version.tenantid
+                    AND document_mapping.id = temp_version.sourceobjectid """)
+
+
+    }
+
+
+    def updateArchDocumentMappingVersion() {
+        sql.execute("""
+                    UPDATE arch_document_mapping SET version = temp_arch_version.new_version
+                    FROM temp_arch_version
+                    WHERE arch_document_mapping.tenantid = temp_arch_version.tenantid
+                    AND arch_document_mapping.id = temp_arch_version.id """)
+
+
+    }
+
+
+    def dropTempSequence() {
+        sql.execute("drop sequence seq_document")
+
+    }
+
+}

--- a/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocumentSqlServer.groovy
+++ b/bonita-migration-distrib/src/main/groovy/org/bonitasoft/migration/versions/v6_3_9_to_6_4_0/MigrateDocumentSqlServer.groovy
@@ -1,0 +1,146 @@
+/*
+ *
+ * Copyright (C) 2016 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bonitasoft.migration.versions.v6_3_9_to_6_4_0
+/**
+ * @author Laurent Leseigneur
+ */
+class MigrateDocumentSqlServer extends MigrateDocument {
+
+    public MigrateDocumentSqlServer(def sql, def tenantId, def nextId, def falseValue, def trueValue) {
+        super(sql, tenantId, nextId, falseValue, trueValue)
+    }
+
+
+    def createTempSequence() {
+        return
+    }
+
+    def createTempDocTable() {
+        sql.execute("""
+                        CREATE TABLE temp_doc (
+                            tenant_id NUMERIC(19, 0) NOT NULL,
+                            doc_mapping_id NUMERIC(19, 0) NOT NULL,
+                            doc_id NUMERIC(19, 0) IDENTITY (""" + nextId + """,1) NOT NULL,
+                            PRIMARY KEY (doc_id)
+                            )  """)
+        sql.execute("""
+                        INSERT INTO temp_doc (tenant_id, doc_mapping_id)
+                        SELECT  d.tenantid, d.id
+                        FROM    document_mapping d
+                        WHERE   tenantid = ? AND documentHasContent = ? """, tenantId, falseValue)
+        sql.execute("CREATE INDEX temp_doc_idx ON temp_doc(tenant_id,doc_mapping_id)")
+    }
+
+    def updateDocumentMapping() {
+        sql.execute("""
+                    UPDATE document_mapping SET documentid = t.doc_id
+                    FROM temp_doc t
+                    WHERE tenantid = t.tenant_id
+                    AND id = t.doc_mapping_id """)
+
+
+    }
+
+    def createTempArchDocTable() {
+        def nextValue = sql.firstRow("SELECT MAX(doc_id) +1  AS nextValue from temp_doc").nextValue
+        sql.execute("""
+                        CREATE TABLE temp_arch_doc (
+                            tenant_id NUMERIC(19, 0) NOT NULL,
+                            arch_doc_mapping_id NUMERIC(19, 0) NOT NULL,
+                            doc_id NUMERIC(19, 0)  IDENTITY (""" + nextValue + """,1) NOT NULL,
+                            PRIMARY KEY (doc_id)
+                            ) """)
+
+        sql.execute("""
+                        INSERT INTO temp_arch_doc (tenant_id, arch_doc_mapping_id)
+                        SELECT  d.tenantid, d.id
+                        FROM    arch_document_mapping d
+                        WHERE   d.tenantid = ? AND d.documentHasContent = ? """, tenantId, falseValue)
+
+
+    }
+
+    def updateArchDocumentMapping() {
+        sql.execute("""
+                    UPDATE arch_document_mapping SET documentid = t.doc_id
+                    FROM temp_arch_doc t
+                    WHERE tenantid = t.tenant_id
+                    AND id = t.arch_doc_mapping_id """)
+
+    }
+
+    def updateSequenceValue() {
+        def nextValue = sql.firstRow("SELECT MAX(doc_id) +1  AS nextValue from temp_arch_doc").nextValue
+        sql.execute("""
+                    UPDATE sequence SET nextid = ?
+                    WHERE tenantid = ?
+                    AND id = 10090 """, nextValue, tenantId)
+
+    }
+
+    def createTempArchVersionTable() {
+        sql.execute("""
+                    SELECT
+                        a.tenantid,
+                        a.id,
+                        a.sourceobjectid,
+                        rank() OVER(
+                                PARTITION BY a.tenantid, a.sourceobjectid
+                                ORDER BY documentCreationDate,id ASC
+                        ) as new_version
+                    INTO temp_arch_version
+                    FROM arch_document_mapping a
+                    WHERE a.tenantid =  """ + tenantId)
+    }
+
+    def createTempVersionTable() {
+
+        sql.execute("""
+                    SELECT
+                        a.tenantid,
+                        a.sourceobjectid,
+                        (max(a.new_version) +1 ) as new_version
+                    INTO temp_version
+                    FROM temp_arch_version a
+                    WHERE a.tenantid = """ + tenantId + " GROUP BY a.tenantid, a.sourceobjectid ")
+    }
+
+    def updateDocumentMappingVersion() {
+        sql.execute("""
+                    UPDATE document_mapping SET version = temp_version.new_version
+                    FROM temp_version
+                    WHERE document_mapping.tenantid = temp_version.tenantid
+                    AND document_mapping.id = temp_version.sourceobjectid """)
+
+    }
+
+    def updateArchDocumentMappingVersion() {
+
+        sql.execute("""
+                    UPDATE arch_document_mapping SET version = temp_arch_version.new_version
+                    FROM temp_arch_version
+                    WHERE arch_document_mapping.tenantid = temp_arch_version.tenantid
+                    AND arch_document_mapping.id = temp_arch_version.id """)
+
+
+    }
+
+    def dropTempSequence() {
+        return
+    }
+
+}

--- a/bonita-migration-scripts-integration-tests/src/main/groovy/org/bonitasoft/migration/versions/v6_3_x_to_6_4_0/ChangeDocumentsStructureIT.groovy
+++ b/bonita-migration-scripts-integration-tests/src/main/groovy/org/bonitasoft/migration/versions/v6_3_x_to_6_4_0/ChangeDocumentsStructureIT.groovy
@@ -45,6 +45,7 @@ class ChangeDocumentsStructureIT extends GroovyTestCase {
 
             //sequences
             sequence tenantid: 1, id: 10090, nextid: 304
+            sequence tenantid: 2, id: 10090, nextid: 235
 
             document_content tenantid: 1, id: 99, documentId: '-4561234568646477', content: "the old content1".getBytes()
             document_content tenantid: 1, id: 100, documentId: '-4561234568646452', content: "the content1".getBytes()
@@ -77,6 +78,7 @@ class ChangeDocumentsStructureIT extends GroovyTestCase {
             arch_document_mapping tenantid: 1, id: 1316, sourceobjectid: 300, processinstanceid: 800, documentName: "oldmydoc1", documentAuthor: 901, documentCreationDate: 4567890017, documentHasContent: falseValue(), documentContentFileName: "oldfile2.txt", documentContentMimeType: "plain/text", contentStorageId: '[NULL]', documentURL: "http//myurl.com/myfile215.txt", archivedate: 4567892116
             arch_document_mapping tenantid: 1, id: 1317, sourceobjectid: 299, processinstanceid: 804, documentName: "archedDoc", documentAuthor: 901, documentCreationDate: 4567892325, documentHasContent: falseValue(), documentContentFileName: "archedDoc.txt", documentContentMimeType: "plain/text", contentStorageId: '[NULL]', documentURL: "http//myurl.com/myfile.txt", archivedate: 4567892315
         }
+
         tester.onSetup();
     }
 
@@ -88,12 +90,14 @@ class ChangeDocumentsStructureIT extends GroovyTestCase {
     }
 
     private void dropTestTables() {
-        def String[] strings = ["document_mapping",
-                                "arch_document_mapping",
-                                "document",
-                                "tenant",
-                                "sequence"]
-        dropTables(sql, strings)
+        def String[] tables = ["document_mapping",
+                               "arch_document_mapping",
+                               "document",
+                               "tenant",
+                               "sequence"]
+
+
+        dropTables(sql, tables)
     }
 
 
@@ -123,6 +127,7 @@ class ChangeDocumentsStructureIT extends GroovyTestCase {
         CustomAssertion.assertEquals dataSet {
 
             sequence tenantid: 1, id: 10090, nextid: 321
+            sequence tenantid: 2, id: 10090, nextid: 235
 
             document tenantid: 1, id: 99, author: 901, creationdate: 4567890001, hascontent: trueValue(), filename: "oldfile1.txt", mimetype: "plain/text", content: "the old content1".getBytes(), url: "[NULL]"
             document tenantid: 1, id: 100, author: 900, creationdate: 4567890003, hascontent: trueValue(), filename: "file1.txt", mimetype: "plain/text", content: "the content1".getBytes(), url: "[NULL]"


### PR DESCRIPTION
* on large volumes document migration fails
* replace atomic  groovy sql DML by massive sql queries
* introduce temporary sequence and tables to allow thoses updates
* use prepared statements
* split db vendor specific syntax

Closes [BS-15031](https://bonitasoft.atlassian.net/browse/BS-15031)